### PR TITLE
microcms-rich-editor-handlerの利用

### DIFF
--- a/app/components/MarkdownTemplate.tsx
+++ b/app/components/MarkdownTemplate.tsx
@@ -1,14 +1,29 @@
 import { raw } from 'hono/html'
+import {
+    microCMSRichEditorHandler,
+    responsiveImageTransformer,
+    tocExtractor
+} from 'microcms-rich-editor-handler';
 
 type Props = {
     body: string
 }
 
 
-export const MarkdownTemplate = ({ body }: Props) => {
+export const MarkdownTemplate = async ({ body }: Props) => {
+    const { html, data } = await microCMSRichEditorHandler(
+        body, // MicroCMSから取得したデータのリッチエディタのHTML文字列
+        {
+            transformers: [responsiveImageTransformer()],
+            extractors: {
+                toc: [tocExtractor(), { phase: "before" }],
+            },
+        },
+    );
+
     return (
         <div class="md">
-            {raw(body)}
+            {raw(html)}
         </div>
     )
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "dayjs": "^1.11.10",
     "hono": "^4.6.20",
     "honox": "^0.1.33",
-    "microcms-js-sdk": "^3.1.0"
+    "microcms-js-sdk": "^3.1.0",
+    "microcms-rich-editor-handler": "^1.0.1",
+    "shiki": "^2.2.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240529.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,6 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [honox({ devServer: { adapter } }), build()],
   ssr: {
-    external: ['microcms-js-sdk', 'dayjs']
+    external: ['microcms-js-sdk', 'dayjs', 'microcms-rich-editor-handler', 'shiki']
   },
 })


### PR DESCRIPTION
タイトルの通りhtml生成時にmicrocms-rich-editor-handlerを利用。

```jsx
import { raw } from 'hono/html'
import {
    microCMSRichEditorHandler,
    responsiveImageTransformer,
    tocExtractor
} from 'microcms-rich-editor-handler';

type Props = {
    body: string
}


export const MarkdownTemplate = async ({ body }: Props) => {
    const { html, data } = await microCMSRichEditorHandler(
        body, // MicroCMSから取得したデータのリッチエディタのHTML文字列
        {
            transformers: [responsiveImageTransformer()],
            extractors: {
                toc: [tocExtractor(), { phase: "before" }],
            },
        },
    );

    return (
        <div class="md">
            {raw(html)}
        </div>
    )
}
```