### PR TITLE
refactor: migrate from relatedPostIds to relatedPosts field

### DIFF
--- a/app/routes/post/[id]/index.tsx
+++ b/app/routes/post/[id]/index.tsx
@@ -3,32 +3,13 @@ import type { Meta } from "../../../types/meta";
 import { config } from "../../../settings/siteSettings";
 import { DetailContent } from "../../../components/DetailContent";
 import { getMicroCMSClient, getPostDetail } from "../../../libs/microcms";
-import type { RelatedPosts } from "../../../types/blog";
 
 export default createRoute(async (c) => {
   const { id } = c.req.param();
   const client = getMicroCMSClient(c.env.SERVICE_DOMAIN, c.env.API_KEY);
   const post = await getPostDetail(client, id);
   const contentUrl = config.siteURL + `/post/${id}`;
-  const relatedPostIds = post.relatedPostIds;
-  let relatedPosts: RelatedPosts | undefined;
-  
-  if (relatedPostIds && relatedPostIds.trim()) {
-    relatedPosts = [];
-    for (const postId of relatedPostIds.split(",").map(id => id.trim()).filter(id => id)) {
-      const relatedPost = getPostDetail(client, postId, { fields: "id,title,description,publishedAt" });
-      const post = await relatedPost;
-      relatedPosts.push({ 
-        id: postId, 
-        title: post.title,
-        description: post.description,
-        publishedAt: post.publishedAt
-      });
-    }
-    if (relatedPosts.length === 0) {
-      relatedPosts = undefined;
-    }
-  }
+  const relatedPosts = post.relatedPosts && post.relatedPosts.length > 0 ? post.relatedPosts : undefined;
   
   const meta: Meta = {
     title: post.title,

--- a/app/types/blog.ts
+++ b/app/types/blog.ts
@@ -28,6 +28,8 @@ export type Body = {
 } & RichEditor &
   AmazonAssociateLink;
 
+
+
 export type Post = {
   title: string;
   thumbnail: MicroCMSImage;
@@ -38,14 +40,9 @@ export type Post = {
   text: string;
   useRepeatedBody: boolean;
   repeatedBody: Body[];
-  relatedPostIds:string;
+  relatedPosts: RelatedPost[];
 } & MicroCMSListContent;
 
-export type RelatedPost={
-  id:string,
-  title:string,
-  description:string,
-  publishedAt:MicroCMSDate['publishedAt']
-}
-export type RelatedPosts=RelatedPost[]
+export type RelatedPost = Pick<Post, 'id' | 'title' | 'description' | 'publishedAt'>;
+export type RelatedPosts = RelatedPost[];
 export type PostListResponse = MicroCMSListResponse<Post>;


### PR DESCRIPTION
- Update Post type to use relatedPosts array instead of relatedPostIds string
- Simplify related posts retrieval using microCMS relationList feature
- Remove manual ID parsing and individual post fetching logic
- Update RelatedPost type to use Pick utility type for better type safety

🤖 Generated with [Claude Code](https://claude.ai/code)